### PR TITLE
Allow brpid flag items to have Active Effects

### DIFF
--- a/module/actor/actor.mjs
+++ b/module/actor/actor.mjs
@@ -8,6 +8,21 @@ export class BRPActor extends Actor {
   }
 
   prepareBaseData() {
+    this.system.brpidFlagItems = {}
+    for (const i of this.items) {
+      if (i.flags.brp?.brpidFlag?.id) {
+        const parts = i.flags.brp?.brpidFlag?.id.match(/^([^\.]+)\.([^\.]+)\.([^\.]+)$/)
+        if (parts) {
+          if (typeof this.system.brpidFlagItems[parts[1]] === 'undefined') {
+            this.system.brpidFlagItems[parts[1]] = {}
+          }
+          if (typeof this.system.brpidFlagItems[parts[1]][parts[2]] === 'undefined') {
+            this.system.brpidFlagItems[parts[1]][parts[2]] = {}
+          }
+          this.system.brpidFlagItems[parts[1]][parts[2]][parts[3]] = i
+        }
+      }
+    }
   }
 
   prepareDerivedData() {
@@ -108,7 +123,7 @@ export class BRPActor extends Actor {
     for (let itm of actorData.items) {
 
       //Does the item have transferrable effects
-      if (['gear','armour'].includes(itm.type)) {      
+      if (['gear','armour'].includes(itm.type)) {
         if (itm.transferredEffects.length > 0) {
           itm.system.hasEffects= true;
         } else {

--- a/templates/item/skill.html
+++ b/templates/item/skill.html
@@ -146,7 +146,7 @@
               <div class="skill-display">{{localize 'BRP.culture'}}</div>
               <div class="stat-input"><input name="system.cutlure" type="text" value="{{item.system.culture}}" data-dtype="Number" /></div>
               <div class="skill-display">{{localize 'BRP.effects'}}</div>
-              <div class="stat-input"><input name="system.effects" type="text" value="{{item.system.effects}}" data-dtype="Number" /></div>
+              <div class="skill-display centre bold">{{item.system.effects}}</div>
             {{/if}}
           {{else}}
             <div class="skill-display">{{localize 'BRP.base'}}</div>


### PR DESCRIPTION
Prevent editing effect on skills sheet, this is because the active effect will be added and shown as an input so each time the sheet is used the value will be duplicated.

Add system.brpidFlagItems to actors
Split flag id (i).(skill).(jump) as FoundryVTT splits keys on . when applying Active Effects
e.g.
system.brpidFlagItems.i.skill.jump.system.effects

Currently there is no UI for adding this