### PR TITLE
Fix incorrectly deleted effects use async function

### DIFF
--- a/module/item/item.mjs
+++ b/module/item/item.mjs
@@ -179,13 +179,13 @@ export class BRPItem extends Item {
     return created
   }
 
-  _onDelete(options, userId) {
-    super._onDelete(options, userId);
-    if (options.parent) {
-      const ids = options.parent.effects.filter(e => e.origin === this.uuid).map(e => e.id)
+  async _preDelete(options, user) {
+    if (this.parent) {
+      const ids = this.parent.effects.filter(e => e.origin === this.uuid).map(e => e.id)
       if (ids.length) {
-        effectData.document.deleteEmbeddedDocuments('ActiveEffect', ids)
+        await this.parent.deleteEmbeddedDocuments('ActiveEffect', ids)
       }
     }
+    return super._preDelete(options, user);
   }
 }

--- a/module/sheets/brp-active-effect-sheet.mjs
+++ b/module/sheets/brp-active-effect-sheet.mjs
@@ -65,15 +65,20 @@ export class BRPActiveEffectSheet {
     for (let eff of aEffects) {
       let brpAE = await fromUuid(eff.uuid)
       let item = await fromUuid(brpAE.origin)
-      for (let chng of brpAE.changes) {
-        effects.push({
-          id: item.id,
-          sourceName: item.name,
-          key: chng.key,
-          name: game.i18n.localize((effectKeys[chng.key] ?? chng.key)),
-          value: chng.value,
-          isActive: brpAE.active ?? false
-        })
+      if (item) {
+        for (let chng of brpAE.changes) {
+          effects.push({
+            id: item.id,
+            sourceName: item.name,
+            key: chng.key,
+            name: game.i18n.localize((effectKeys[chng.key] ?? chng.key)),
+            value: chng.value,
+            isActive: brpAE.active ?? false
+          })
+        }
+      } else if (brpAE) {
+        // Fix for incorrectly deleted item/effect combos, sorry
+        await brpAE.delete()
       }
     }
     return effects


### PR DESCRIPTION
Switch to an async before delete function so we can await for the delete effects action to complete

brp-active-effect-sheet.mjs - when loading actor delete effects for items that were already deleted, this code can be removed once the broken Actor is fixed.