### PR TITLE
Chaosium Canvas Interface: Play Sound, Button Triggers, duplicate Region Behaviours

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -809,7 +809,16 @@
       "title": "Edit System ID (BRPID)"
     },
     "ChaosiumCanvasInterface": {
+      "Buttons": {
+        "Both": "Both Mouse Buttons",
+        "Left": "Left Mouse Button",
+        "Right": "Right Mouse Button"
+      },
       "DrawingToggle": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Toggle": {
           "Title": "Show",
           "Hint": "Should this show or hide the the drawing and documents"
@@ -834,16 +843,36 @@
           "Title": "Permission for Journal Entries",
           "Hint": "When set to show set Document ownership to this level"
         },
+        "PermissionDocumentHide": {
+          "Title": "Hide Permission for Journal Entries",
+          "Hint": "When set to hide set Document ownership to this level"
+        },
         "PermissionPage": {
           "Title": "Permission for Journal Entry Pages",
           "Hint": "When set to show set Journal Entry Page ownership to this level"
         },
-        "RegionUuids": {
-          "Title": "Then trigger these CCI Regions on Right Click",
+        "PermissionPageHide": {
+          "Title": "Hide Permission for Journal Entry Pages",
+          "Hint": "When set to hide set Journal Entry Page ownership to this level"
+        },
+        "TriggerButton": {
+          "Title": "Trigger Region Button",
+          "Hint": "If Mouse Button is Both, and this button is used trigger the following region"
+        },
+        "TriggerRegionUuids": {
+          "Title": "Trigger This Region",
+          "Hint": ""
+        },
+        "TriggerAsButton": {
+          "Title": "With A Button Click",
           "Hint": ""
         }
       },
       "MapPinToggle": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Toggle": {
           "Title": "Show",
           "Hint": "Should this show or hide the the map note and documents"
@@ -866,6 +895,10 @@
         }
       },
       "OpenDocument": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Permission": {
           "Title": "Can click if",
           "Hint": ""
@@ -885,7 +918,29 @@
         "GM": "GM",
         "SeeTile": "See Tile"
       },
+      "PlaySound": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
+        "Playlist": {
+          "Title": "Select Playlist",
+          "Hint": ""
+        },
+        "Sound": {
+          "Title": "Select Playlist Sound",
+          "Hint": ""
+        },
+        "Toggle": {
+          "Title": "Play",
+          "Hint": "Should this play or stop playback"
+        }
+      },
       "ToScene": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Permission": {
           "Title": "Can click if",
           "Hint": ""
@@ -900,6 +955,10 @@
         }
       },
       "TileToggle": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Toggle": {
           "Title": "Show",
           "Hint": "Should this show or hide the the tile and documents"
@@ -924,12 +983,28 @@
           "Title": "Permission for Journal Entries",
           "Hint": "When set to show set Document ownership to this level"
         },
+        "PermissionDocumentHide": {
+          "Title": "Hide Permission for Journal Entries",
+          "Hint": "When set to hide set Document ownership to this level"
+        },
         "PermissionPage": {
           "Title": "Permission for Journal Entry Pages",
           "Hint": "When set to show set Journal Entry Page ownership to this level"
         },
-        "RegionUuids": {
-          "Title": "Then trigger these CCI Regions on Right Click",
+        "PermissionPageHide": {
+          "Title": "Hide Permission for Journal Entry Pages",
+          "Hint": "When set to hide set Journal Entry Page ownership to this level"
+        },
+        "TriggerButton": {
+          "Title": "Trigger Region Button",
+          "Hint": "If Mouse Button is Both, and this button is used trigger the following region"
+        },
+        "TriggerRegionUuids": {
+          "Title": "Trigger This Region",
+          "Hint": ""
+        },
+        "TriggerAsButton": {
+          "Title": "With A Button Click",
           "Hint": ""
         }
       }
@@ -940,6 +1015,7 @@
       "ChaosiumCanvasInterfaceDrawingToggle": "CCI: Drawing Toggle",
       "ChaosiumCanvasInterfaceMapPinToggle": "CCI: Map Pin Toggle",
       "ChaosiumCanvasInterfaceOpenDocument": "CCI: Open Document",
+      "ChaosiumCanvasInterfacePlaySound": "CCI: Play Sound",
       "ChaosiumCanvasInterfaceToScene": "CCI: To Scene",
       "ChaosiumCanvasInterfaceTileToggle": "CCI: Tile Toggle"
     }

--- a/module/apps/chaosium-canvas-interface-init.mjs
+++ b/module/apps/chaosium-canvas-interface-init.mjs
@@ -1,6 +1,7 @@
 import ChaosiumCanvasInterfaceDrawingToggle from "./chaosium-canvas-interface-drawing-toggle.mjs";
 import ChaosiumCanvasInterfaceMapPinToggle from "./chaosium-canvas-interface-map-pin-toggle.mjs";
 import ChaosiumCanvasInterfaceOpenDocument from "./chaosium-canvas-interface-open-document.mjs";
+import ChaosiumCanvasInterfacePlaySound from "./chaosium-canvas-interface-play-sound.mjs";
 import ChaosiumCanvasInterfaceToScene from "./chaosium-canvas-interface-to-scene.mjs";
 import ChaosiumCanvasInterfaceTileToggle from "./chaosium-canvas-interface-tile-toggle.mjs";
 import ChaosiumCanvasInterface from "./chaosium-canvas-interface.mjs";
@@ -11,6 +12,7 @@ export default class ChaosiumCanvasInterfaceInit extends ChaosiumCanvasInterface
       ChaosiumCanvasInterfaceDrawingToggle,
       ChaosiumCanvasInterfaceMapPinToggle,
       ChaosiumCanvasInterfaceOpenDocument,
+      ChaosiumCanvasInterfacePlaySound,
       ChaosiumCanvasInterfaceToScene,
       ChaosiumCanvasInterfaceTileToggle
     ]

--- a/module/apps/chaosium-canvas-interface-map-pin-toggle.mjs
+++ b/module/apps/chaosium-canvas-interface-map-pin-toggle.mjs
@@ -18,8 +18,13 @@ export default class ChaosiumCanvasInterfaceMapPinToggle extends ChaosiumCanvasI
   static defineSchema () {
     const fields = foundry.data.fields
     return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'BRP.ChaosiumCanvasInterface.MapPinToggle.Button.Title',
+        hint: 'BRP.ChaosiumCanvasInterface.MapPinToggle.Button.Hint'
+      }),
       toggle: new fields.BooleanField({
-        initial: false,
         label: 'BRP.ChaosiumCanvasInterface.MapPinToggle.Toggle.Title',
         hint: 'BRP.ChaosiumCanvasInterface.MapPinToggle.Toggle.Hint'
       }),
@@ -61,7 +66,7 @@ export default class ChaosiumCanvasInterfaceMapPinToggle extends ChaosiumCanvasI
     return game.user.isGM
   }
 
-  async _handleLeftClickEvent () {
+  async #handleClickEvent () {
     game.socket.emit('system.brp', { type: 'toggleMapNotes', toggle: true })
     game.settings.set('core', foundry.canvas.layers.NotesLayer.TOGGLE_SETTING, true)
     for (const uuid of this.documentUuids) {
@@ -81,6 +86,18 @@ export default class ChaosiumCanvasInterfaceMapPinToggle extends ChaosiumCanvasI
       } else {
         console.error('Note ' + uuid + ' not loaded')
       }
+    }
+  }
+
+  async _handleLeftClickEvent () {
+    if (this.triggerButton === ChaosiumCanvasInterface.triggerButton.Left) {
+      this.#handleClickEvent()
+    }
+  }
+
+  async _handleRightClickEvent () {
+    if (this.triggerButton === ChaosiumCanvasInterface.triggerButton.Right) {
+      this.#handleClickEvent()
     }
   }
 }

--- a/module/apps/chaosium-canvas-interface-open-document.mjs
+++ b/module/apps/chaosium-canvas-interface-open-document.mjs
@@ -16,6 +16,12 @@ export default class ChaosiumCanvasInterfaceOpenDocument extends ChaosiumCanvasI
   static defineSchema () {
     const fields = foundry.data.fields
     return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'BRP.ChaosiumCanvasInterface.OpenDocument.Button.Title',
+        hint: 'BRP.ChaosiumCanvasInterface.OpenDocument.Button.Hint'
+      }),
       permission: new fields.StringField({
         blank: false,
         choices: Object.keys(ChaosiumCanvasInterfaceOpenDocument.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceOpenDocument.PERMISSIONS[k]); return c }, {}),
@@ -53,18 +59,28 @@ export default class ChaosiumCanvasInterfaceOpenDocument extends ChaosiumCanvasI
     return false
   }
 
-  async _handleLeftClickEvent () {
-    if (this.documentUuid) {
-      const doc = await fromUuid(this.documentUuid)
-      if (doc?.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER)) {
-        if (doc instanceof JournalEntryPage) {
-          doc.parent.sheet.render(true, { pageId: doc.id, anchor: this.anchor })
-        } else {
-          doc.sheet.render(true)
-        }
+  async #handleClickEvent () {
+    const doc = await fromUuid(this.documentUuid)
+    if (doc?.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER)) {
+      if (doc instanceof JournalEntryPage) {
+        doc.parent.sheet.render(true, { pageId: doc.id, anchor: this.anchor })
       } else {
-        console.error('Document ' + this.documentUuid + ' not loaded')
+        doc.sheet.render(true)
       }
+    } else {
+      console.error('Document ' + this.documentUuid + ' not loaded')
+    }
+  }
+
+  async _handleLeftClickEvent () {
+    if (this.documentUuid && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Left) {
+      this.#handleClickEvent()
+    }
+  }
+
+  async _handleRightClickEvent () {
+    if (this.documentUuid && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Right) {
+      this.#handleClickEvent()
     }
   }
 }

--- a/module/apps/chaosium-canvas-interface-play-sound.mjs
+++ b/module/apps/chaosium-canvas-interface-play-sound.mjs
@@ -1,0 +1,77 @@
+import ChaosiumCanvasInterface from "./chaosium-canvas-interface.mjs";
+
+export default class ChaosiumCanvasInterfacePlaySound extends ChaosiumCanvasInterface {
+  static get icon () {
+    return 'fa-solid fa-music'
+  }
+
+  static defineSchema () {
+    const fields = foundry.data.fields
+    return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'BRP.ChaosiumCanvasInterface.PlaySound.Button.Title',
+        hint: 'BRP.ChaosiumCanvasInterface.PlaySound.Button.Hint'
+      }),
+      toggle: new fields.BooleanField({
+        initial: false,
+        label: 'BRP.ChaosiumCanvasInterface.PlaySound.Toggle.Title',
+        hint: 'BRP.ChaosiumCanvasInterface.PlaySound.Toggle.Hint'
+      }),
+      playlistUuid: new fields.DocumentUUIDField({
+        label: 'BRP.ChaosiumCanvasInterface.PlaySound.Playlist.Title',
+        hint: 'BRP.ChaosiumCanvasInterface.PlaySound.Playlist.Hint',
+        type: 'Playlist'
+      }),
+      soundUuid: new fields.DocumentUUIDField({
+        label: 'BRP.ChaosiumCanvasInterface.PlaySound.Sound.Title',
+        hint: 'BRP.ChaosiumCanvasInterface.PlaySound.Sound.Hint',
+        type: 'PlaylistSound'
+      })
+    }
+  }
+
+  async _handleMouseOverEvent () {
+    return game.user.isGM
+  }
+
+  async #handleClickEvent () {
+    if (this.playlistUuid) {
+      const playList = await fromUuid(this.playlistUuid)
+      if (playList) {
+        if (this.toggle) {
+          playList.playAll()
+        } else {
+          playList.stopAll()
+        }
+      } else {
+        console.error('Playlist ' + this.sceneUuid + ' not loaded')
+      }
+    }
+    if (this.soundUuid) {
+      const sound = await fromUuid(this.soundUuid)
+      if (sound) {
+        if (this.toggle) {
+          sound.parent.playSound(sound)
+        } else {
+          sound.parent.stopSound(sound)
+        }
+      } else {
+        console.error('Sound ' + this.sceneUuid + ' not loaded')
+      }
+    }
+  }
+
+  async _handleLeftClickEvent () {
+    if ((this.playlistUuid || this.soundUuid) && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Left) {
+      this.#handleClickEvent()
+    }
+  }
+
+  async _handleRightClickEvent () {
+    if ((this.playlistUuid || this.soundUuid) && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Right) {
+      this.#handleClickEvent()
+    }
+  }
+}

--- a/module/apps/chaosium-canvas-interface-tile-toggle.mjs
+++ b/module/apps/chaosium-canvas-interface-tile-toggle.mjs
@@ -15,11 +15,28 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
     return 'fa-solid fa-cubes'
   }
 
+  static get triggerButtons () {
+    const buttons = super.triggerButtons
+    buttons[ChaosiumCanvasInterfaceTileToggle.triggerButton.Both] = 'BRP.ChaosiumCanvasInterface.Buttons.Both'
+    return buttons
+  }
+
+  static get triggerButton () {
+    const button = super.triggerButton
+    button.Both = 20
+    return button
+  }
+
   static defineSchema () {
     const fields = foundry.data.fields
     return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterfaceTileToggle.triggerButtons,
+        initial: ChaosiumCanvasInterfaceTileToggle.triggerButton.Left,
+        label: 'BRP.ChaosiumCanvasInterface.TileToggle.Button.Title',
+        hint: 'BRP.ChaosiumCanvasInterface.TileToggle.Button.Hint'
+      }),
       toggle: new fields.BooleanField({
-        initial: false,
         label: 'BRP.ChaosiumCanvasInterface.TileToggle.Toggle.Title',
         hint: 'BRP.ChaosiumCanvasInterface.TileToggle.Toggle.Hint'
       }),
@@ -48,6 +65,13 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
         hint: 'BRP.ChaosiumCanvasInterface.TileToggle.PermissionDocument.Hint',
         required: true
       }),
+      permissionDocumentHide: new fields.NumberField({
+        choices: Object.keys(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS[k]); return c }, {}),
+        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE,
+        label: 'BRP.ChaosiumCanvasInterface.TileToggle.PermissionDocumentHide.Title',
+        hint: 'BRP.ChaosiumCanvasInterface.TileToggle.PermissionDocumentHide.Hint',
+        required: true
+      }),
       journalEntryPageUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           type: 'JournalEntryPage'
@@ -64,6 +88,13 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
         hint: 'BRP.ChaosiumCanvasInterface.TileToggle.PermissionPage.Hint',
         required: true
       }),
+      permissionPageHide: new fields.NumberField({
+        choices: Object.keys(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceTileToggle.PERMISSIONS[k]); return c }, {}),
+        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE,
+        label: 'BRP.ChaosiumCanvasInterface.TileToggle.PermissionPageHide.Title',
+        hint: 'BRP.ChaosiumCanvasInterface.TileToggle.PermissionPageHide.Hint',
+        required: true
+      }),
       regionBehaviorUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           type: 'RegionBehavior'
@@ -73,23 +104,42 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
           hint: 'BRP.ChaosiumCanvasInterface.TileToggle.RegionBehavior.Hint'
         }
       ),
+      regionButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Right,
+        label: 'BRP.ChaosiumCanvasInterface.TileToggle.TriggerButton.Title',
+        hint: 'BRP.ChaosiumCanvasInterface.TileToggle.TriggerButton.Hint'
+      }),
       regionUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           type: 'Region'
         }),
         {
-          label: 'BRP.ChaosiumCanvasInterface.TileToggle.RegionUuids.Title',
-          hint: 'BRP.ChaosiumCanvasInterface.TileToggle.RegionUuids.Hint'
+          label: 'BRP.ChaosiumCanvasInterface.TileToggle.TriggerRegionUuids.Title',
+          hint: 'BRP.ChaosiumCanvasInterface.TileToggle.TriggerRegionUuids.Hint'
         }
       ),
+      triggerAsButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'BRP.ChaosiumCanvasInterface.TileToggle.TriggerAsButton.Title',
+        hint: 'BRP.ChaosiumCanvasInterface.TileToggle.TriggerAsButton.Hint'
+      }),
     }
+  }
+
+  static migrateData (source) {
+    if (typeof source.triggerButton === 'undefined' && source.regionUuids?.length) {
+      source.triggerButton = ChaosiumCanvasInterfaceTileToggle.triggerButton.Both
+    }
+    return source
   }
 
   async _handleMouseOverEvent () {
     return game.user.isGM
   }
 
-  async _handleLeftClickEvent () {
+  async #handleClickEvent (button) {
     for (const uuid of this.tileUuids) {
       const doc = await fromUuid(uuid)
       if (doc) {
@@ -98,8 +148,8 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
         console.error('Tile ' + uuid + ' not loaded')
       }
     }
-    const permissionDocument = (!this.toggle ? CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE : this.permissionDocument)
-    const permissionPage = (!this.toggle ? CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE : this.permissionPage)
+    const permissionDocument = (!this.toggle ? this.permissionDocumentHide : this.permissionDocument)
+    const permissionPage = (!this.toggle ? this.permissionPageHide : this.permissionPage)
     for (const uuid of this.journalEntryUuids) {
       const doc = await fromUuid(uuid)
       if (doc) {
@@ -124,12 +174,30 @@ export default class ChaosiumCanvasInterfaceTileToggle extends ChaosiumCanvasInt
         console.error('Region Behavior ' + uuid + ' not loaded')
       }
     }
+    if (this.triggerButton === ChaosiumCanvasInterfaceTileToggle.triggerButton.Both) {
+      for (const uuid of this.regionUuids) {
+        setTimeout(() => {
+          if (button === this.regionButton) {
+            if (this.triggerAsButton === ChaosiumCanvasInterface.triggerButton.Right) {
+              game.brp.ClickRegionRightUuid(uuid)
+            } else if (this.triggerAsButton === ChaosiumCanvasInterface.triggerButton.Left) {
+              game.brp.ClickRegionLeftUuid(uuid)
+            }
+          }
+        }, 100)
+      }
+    }
   }
 
-  async _handleRightClickEvent () {
-    await this._handleLeftClickEvent()
-    for (const uuid of this.regionUuids) {
-      game.brp.ClickRegionLeftUuid(uuid)
+  async _handleLeftClickEvent() {
+    if ([ChaosiumCanvasInterfaceTileToggle.triggerButton.Both, ChaosiumCanvasInterface.triggerButton.Left].includes(this.triggerButton)) {
+      this.#handleClickEvent(ChaosiumCanvasInterface.triggerButton.Left)
+    }
+  }
+
+  async _handleRightClickEvent() {
+    if ([ChaosiumCanvasInterfaceTileToggle.triggerButton.Both, ChaosiumCanvasInterface.triggerButton.Right].includes(this.triggerButton)) {
+      this.#handleClickEvent(ChaosiumCanvasInterface.triggerButton.Right)
     }
   }
 }

--- a/module/apps/chaosium-canvas-interface-to-scene.mjs
+++ b/module/apps/chaosium-canvas-interface-to-scene.mjs
@@ -16,6 +16,12 @@ export default class ChaosiumCanvasInterfaceToScene extends ChaosiumCanvasInterf
   static defineSchema () {
     const fields = foundry.data.fields
     return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'BRP.ChaosiumCanvasInterface.ToScene.Button.Title',
+        hint: 'BRP.ChaosiumCanvasInterface.ToScene.Button.Hint'
+      }),
       permission: new fields.StringField({
         blank: false,
         choices: Object.keys(ChaosiumCanvasInterfaceToScene.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceToScene.PERMISSIONS[k]); return c }, {}),
@@ -54,16 +60,26 @@ export default class ChaosiumCanvasInterfaceToScene extends ChaosiumCanvasInterf
     return false
   }
 
-  async _handleLeftClickEvent () {
-    if (this.sceneUuid) {
-      const doc = await fromUuid(this.sceneUuid)
-      if (doc) {
-        setTimeout(() => {
-          doc.view()
-        }, 100)
-      } else {
-        console.error('Scene ' + this.sceneUuid + ' not loaded')
-      }
+  async #handleClickEvent () {
+    const doc = await fromUuid(this.sceneUuid)
+    if (doc) {
+      setTimeout(() => {
+        doc.view()
+      }, 100)
+    } else {
+      console.error('Scene ' + this.sceneUuid + ' not loaded')
+    }
+  }
+
+  async _handleLeftClickEvent() {
+    if (this.sceneUuid && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Left) {
+      this.#handleClickEvent()
+    }
+  }
+
+  async _handleRightClickEvent() {
+    if (this.sceneUuid && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Right) {
+      this.#handleClickEvent()
     }
   }
 }

--- a/module/apps/chaosium-canvas-interface.mjs
+++ b/module/apps/chaosium-canvas-interface.mjs
@@ -1,4 +1,18 @@
 export default class ChaosiumCanvasInterface extends foundry.data.regionBehaviors.RegionBehaviorType {
+  static get triggerButtons () {
+    return {
+      [ChaosiumCanvasInterface.triggerButton.Left]: 'BRP.ChaosiumCanvasInterface.Buttons.Left',
+      [ChaosiumCanvasInterface.triggerButton.Right]: 'BRP.ChaosiumCanvasInterface.Buttons.Right'
+    }
+  }
+
+  static get triggerButton () {
+    return {
+      Left: 0,
+      Right: 2
+    }
+  }
+
   static initSelf () {
     const oldOnClickLeft = foundry.canvas.layers.TokenLayer.prototype._onClickLeft
     foundry.canvas.layers.TokenLayer.prototype._onClickLeft = function (event) {

--- a/module/brp.mjs
+++ b/module/brp.mjs
@@ -6,9 +6,8 @@ import { BRPUtilities } from "./apps/utilities.mjs"
 import { BRPMenu } from "./setup/menu.mjs"
 import * as Chat from "./apps/chat.mjs";
 import Init from './hooks/init.mjs';
-import renderSceneControls from "./hooks/render-scene-controls.mjs";
-
-
+import renderSceneControls from "./hooks/render-scene-controls.mjs"
+import RenderRegionConfig from './hooks/render-region-config.mjs'
 
 Hooks.once('init', Init);
 
@@ -55,5 +54,4 @@ BRPHooks.listen()
 Hooks.on('getSceneControlButtons', BRPMenu.getButtons)
 Hooks.on('renderSceneControls', renderSceneControls)
 Hooks.on('renderActorSheet', BRPCharacterSheet.renderSheet)
-
-
+Hooks.on('renderRegionConfig', RenderRegionConfig)

--- a/module/hooks/render-region-config.mjs
+++ b/module/hooks/render-region-config.mjs
@@ -1,0 +1,26 @@
+export default function (application, element, context, options) {
+  new foundry.applications.ux.DragDrop({
+    permissions: {
+      drop: true
+    },
+    callbacks: {
+      drop: async (event) => {
+        const dataList = JSON.parse(event.dataTransfer.getData('text/plain'))
+        if (typeof dataList.uuid === 'string') {
+          let behaviors = []
+          switch (dataList.type) {
+            case 'RegionBehavior':
+              behaviors = [(await fromUuid(dataList.uuid)).toObject()]
+              break
+            case 'Region':
+              behaviors = (await fromUuid(dataList.uuid)).toObject().behaviors
+              break
+          }
+          if (behaviors.length) {
+            RegionBehavior.create(behaviors, { parent: application.document })
+          }
+        }
+      }
+    }
+  }).bind(element.querySelector('.tab.region-behaviors'))
+}

--- a/system.json
+++ b/system.json
@@ -74,6 +74,7 @@
       "ChaosiumCanvasInterfaceDrawingToggle": {},
       "ChaosiumCanvasInterfaceMapPinToggle": {},
       "ChaosiumCanvasInterfaceOpenDocument": {},
+      "ChaosiumCanvasInterfacePlaySound": {},
       "ChaosiumCanvasInterfaceToScene": {},
       "ChaosiumCanvasInterfaceTileToggle": {}
     }


### PR DESCRIPTION
- Add ability to pick if Left or Right click will trigger the behaviours
- Add CCI: Play Sound
- Add drop existing Region or Region Behaviour on region behaviour config tab to duplicate them
- Add hide permission to Drawing and Tile to prevent always using None

Migrate existing Toggle Drawing and Tile to Both mouse buttons so that trigger regionUuids continues to work, update trigger to the following process
- Trigger Region Button [Left / Right]
- Trigger This Region [Region]
- With A Button Click [Left / Right]