### PR TITLE
Fix BRPIDEditor crash for unsupported Foundry languages

### DIFF
--- a/module/brpid/brpid-editor.mjs
+++ b/module/brpid/brpid-editor.mjs
@@ -30,7 +30,7 @@ export class BRPIDEditor extends FormApplication {
     sheetData.lang = sheetData.brpidFlag?.lang || game.i18n.lang
     sheetData.priority = sheetData.brpidFlag?.priority || 0
 
-    const BRPIDKeys = foundry.utils.flattenObject(game.i18n.translations.BRP.BRPIDFlag.keys ?? {})
+    const BRPIDKeys = game.system.api.brpid.getBRPIDKeys()
     const prefix = new RegExp('^' + BRPUtilities.quoteRegExp(sheetData.idPrefix))
     sheetData.existingKeys = Object.keys(BRPIDKeys).reduce((obj, k) => {
       if (k.match(prefix)) {

--- a/module/brpid/brpid.mjs
+++ b/module/brpid/brpid.mjs
@@ -13,6 +13,20 @@ export class BRPID {
 
 
   /**
+   * Returns the flattened BRPIDFlag.keys object, falling back
+   * to game.i18n._fallback when the current language is not
+   * supported by the system.
+   * @returns object
+   */
+  static getBRPIDKeys() {
+    const keys =
+      game.i18n.translations?.BRP?.BRPIDFlag?.keys ??
+      game.i18n._fallback?.BRP?.BRPIDFlag?.keys ??
+      {}
+    return foundry.utils.flattenObject(keys)
+  }
+
+  /**
    * Returns RegExp for valid type and format
    * @returns RegExp
    */
@@ -111,7 +125,7 @@ export class BRPID {
    */
   static findBRPIdInList(brpid, list) {
     let itemName = ''
-    const BRPIDKeys = foundry.utils.flattenObject(game.i18n.translations.BRP.BRPIDFlag.keys)
+    const BRPIDKeys = BRPID.getBRPIDKeys()
     if (typeof BRPIDKeys[brpid] !== 'undefined') {
       itemName = BRPIDKeys[brpid]
     }


### PR DESCRIPTION
### Problem
When the Foundry VTT client language is set to anything other than supported languages by BRP, opening the BRPID editor on any item or actor throws:
TypeError: Cannot read properties of undefined (reading 'BRPIDFlag')
    at BRPIDEditor.getData (brpid-editor.mjs:33:78)
The same crash can occur in BRPID.findBRPIdInList() during profession/skill drops.

### Root cause
Both brpid-editor.mjs and brpid.mjs access game.i18n.translations.BRP.BRPIDFlag.keys directly. Foundry's i18n system only populates game.i18n.translations with the strings for the currently selected language. If the system has no translation file for that language, the system's strings go into game.i18n._fallback instead, leaving game.i18n.translations.BRP as undefined.
<img width="673" height="173" alt="image" src="https://github.com/user-attachments/assets/f59bffa6-23fe-4c2d-aff0-f0ac3737eb58" />


### Suggested fix
Added a static method BRPID.getBRPIDKeys() that resolves the keys through a fallback chain:

game.i18n.translations.BRP.BRPIDFlag.keys - current language (if supported)
game.i18n._fallback.BRP.BRPIDFlag.keys - English fallback
{} - empty object as a safe default

Both call sites now use this method instead of accessing the translation object directly.

### Remark
Also, the language dropdown in the BRPID editor doesn't appear to persist the selected value - it resets to English on every render. It looks like the `selectOptions` helper in `brpid-editor.html` is missing the `selected=lang` parameter. Not sure how critical this is, but I can open a separate issue and look into it further if needed.
<img width="1120" height="523" alt="image" src="https://github.com/user-attachments/assets/ccbc7e46-f555-4740-b21b-d7f638224f48" />

Sorry for any code-style issues, JS is not my main language. I will fix any problem if you highlight it to me.
